### PR TITLE
Fix texture loading

### DIFF
--- a/abcg/abcg_image.cpp
+++ b/abcg/abcg_image.cpp
@@ -66,9 +66,6 @@ GLuint abcg::opengl::loadTexture(std::string_view path, bool generateMipmaps) {
     }
     SDL_FreeSurface(surface);
 
-    // Flip horizontally
-    flipY(formattedSurface);
-
     // Generate the texture
     glGenTextures(1, &textureID);
     glBindTexture(GL_TEXTURE_2D, textureID);


### PR DESCRIPTION
When using `ImGui::Image()`, loaded textures are rendered upside down